### PR TITLE
Added handling for 'conj' dependency to transform.py

### DIFF
--- a/idd3/transform.py
+++ b/idd3/transform.py
@@ -454,6 +454,18 @@ class TransformNnJoin(Transformation):
                         and relations[relation.head].word[0].isupper():
                     relation.rel = 'nn-join'
 
+class TransformConj(Transformation):
+    """Replace conjunction with the head's head and relation"""
+
+    def transform(self, relations):
+        for relation in relations:
+            if relation.rel == 'conj':
+                head = relations[relation.head]
+                new_head = head.head
+                new_rel = head.rel
+                relation.rel = new_rel
+                relation.head = new_head
+
 
 all_transformations = [RemovePunctuation(),
                        RemoveParataxisFillers(),
@@ -476,4 +488,5 @@ all_transformations = [RemovePunctuation(),
                        FixAdverbRepetition(),
                        FixReflexivePronouns(),
                        FixXcompAttributions(),
-                       TransformNnJoin()]
+                       TransformNnJoin(),
+                       TransformConj()]


### PR DESCRIPTION
Handling of conj based on example figures from http://nlp.stanford.edu/software/stanford-dependencies.shtml
Figures 1 & 2 on that page show the Standard Stanford dependencies, collapsed and propagated, and the basic dependencies.
 Our handling here is a more basic version of the collapsed and propagated handling, implementing something that we might also call propagation.
